### PR TITLE
Bugfix/lb rule variables

### DIFF
--- a/modules/networking/lb_rule/module.tf
+++ b/modules/networking/lb_rule/module.tf
@@ -17,11 +17,13 @@ resource "azurerm_lb_rule" "lb" {
   protocol                       = var.settings.protocol
   frontend_port                  = var.settings.frontend_port
   backend_port                   = var.settings.backend_port
-  backend_address_pool_ids       = try(var.settings.backend_address_pool_ids, null)
-  probe_id                       = try(var.settings.probe_id, null)
-  enable_floating_ip             = try(var.settings.enable_floating_ip, null)
-  idle_timeout_in_minutes        = try(var.settings.idle_timeout_in_minutes, null)
-  load_distribution              = try(var.settings.load_distribution, null)
-  disable_outbound_snat          = try(var.settings.disable_outbound_snat, null)
-  enable_tcp_reset               = try(var.settings.enable_tcp_reset, null)
+  #backend_address_pool_ids       = try(var.settings.backend_address_pool_ids, null)
+  #probe_id                       = try(var.settings.probe_id, null)
+  backend_address_pool_ids = [can(var.settings.backend_address_pool.id) ? var.settings.backend_address_pool.id : var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id]
+  probe_id                 = can(var.settings.probe.id) ? var.settings.probe.id : var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id
+  enable_floating_ip       = try(var.settings.enable_floating_ip, null)
+  idle_timeout_in_minutes  = try(var.settings.idle_timeout_in_minutes, null)
+  load_distribution        = try(var.settings.load_distribution, null)
+  disable_outbound_snat    = try(var.settings.disable_outbound_snat, null)
+  enable_tcp_reset         = try(var.settings.enable_tcp_reset, null)
 }

--- a/modules/networking/lb_rule/module.tf
+++ b/modules/networking/lb_rule/module.tf
@@ -19,11 +19,11 @@ resource "azurerm_lb_rule" "lb" {
   backend_port                   = var.settings.backend_port
   #backend_address_pool_ids       = try(var.settings.backend_address_pool_ids, null)
   #probe_id                       = try(var.settings.probe_id, null)
-  backend_address_pool_ids = [can(var.settings.backend_address_pool.id) ? var.settings.backend_address_pool.id : var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id]
-  probe_id                 = can(var.settings.probe.id) ? var.settings.probe.id : var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id
-  enable_floating_ip       = try(var.settings.enable_floating_ip, null)
-  idle_timeout_in_minutes  = try(var.settings.idle_timeout_in_minutes, null)
-  load_distribution        = try(var.settings.load_distribution, null)
-  disable_outbound_snat    = try(var.settings.disable_outbound_snat, null)
-  enable_tcp_reset         = try(var.settings.enable_tcp_reset, null)
+  backend_address_pool_ids       = [can(var.settings.backend_address_pool.id) ? var.settings.backend_address_pool.id : var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id]
+  probe_id                       = can(var.settings.probe.id) ? var.settings.probe.id : var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id
+  enable_floating_ip             = try(var.settings.enable_floating_ip, null)
+  idle_timeout_in_minutes        = try(var.settings.idle_timeout_in_minutes, null)
+  load_distribution              = try(var.settings.load_distribution, null)
+  disable_outbound_snat          = try(var.settings.disable_outbound_snat, null)
+  enable_tcp_reset               = try(var.settings.enable_tcp_reset, null)
 }


### PR DESCRIPTION
modules/networking/lb_rule values for the following variables was limited.  It's been changed as follows:

BEFORE:

```hcl
backend_address_pool_ids       = try(var.settings.backend_address_pool_ids, null)
probe_id                       = try(var.settings.probe_id, null)
```
AFTER:

```hcl
backend_address_pool_ids = [can(var.settings.backend_address_pool.id) ? var.settings.backend_address_pool.id : var.remote_objects.backend_address_pool[try(var.settings.backend_address_pool.lz_key, var.client_config.landingzone_key)][var.settings.backend_address_pool.key].id]
probe_id                 = can(var.settings.lb_probe.id) ? var.settings.lb_probe.id : var.remote_objects.lb_probe[try(var.settings.lb_probe.lz_key, var.client_config.landingzone_key)][var.settings.lb_probe.key].id
```

This allows easy to use variables like this:

```hcl
probe_id = {
  key = "ext_lbp1"
}
backend_address_pool_ids = {
  key = "ext_lbap1"
}
```
