### PR TITLE
lb_rule module updated logic

### DIFF
--- a/modules/networking/lb_rule/module.tf
+++ b/modules/networking/lb_rule/module.tf
@@ -17,8 +17,6 @@ resource "azurerm_lb_rule" "lb" {
   protocol                       = var.settings.protocol
   frontend_port                  = var.settings.frontend_port
   backend_port                   = var.settings.backend_port
-  #backend_address_pool_ids       = try(var.settings.backend_address_pool_ids, null)
-  #probe_id                       = try(var.settings.probe_id, null)
   backend_address_pool_ids       = [can(var.settings.backend_address_pool.id) ? var.settings.backend_address_pool.id : var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id]
   probe_id                       = can(var.settings.probe.id) ? var.settings.probe.id : var.remote_objects.lb[try(var.settings.loadbalancer.lz_key, var.client_config.landingzone_key)][var.settings.loadbalancer.key].id
   enable_floating_ip             = try(var.settings.enable_floating_ip, null)


### PR DESCRIPTION
modules/networking/lb_rule values for the following variables was limited.  It's been changed as follows:

BEFORE:

```hcl
backend_address_pool_ids       = try(var.settings.backend_address_pool_ids, null)
probe_id                       = try(var.settings.probe_id, null)
```
AFTER:

```hcl
backend_address_pool_ids = [can(var.settings.backend_address_pool.id) ? var.settings.backend_address_pool.id : var.remote_objects.backend_address_pool[try(var.settings.backend_address_pool.lz_key, var.client_config.landingzone_key)][var.settings.backend_address_pool.key].id]
probe_id                 = can(var.settings.lb_probe.id) ? var.settings.lb_probe.id : var.remote_objects.lb_probe[try(var.settings.lb_probe.lz_key, var.client_config.landingzone_key)][var.settings.lb_probe.key].id
```

This allows easy to use variables like this:

```hcl
probe_id = {
  key = "ext_lbp1"
}
backend_address_pool_ids = {
  key = "ext_lbap1"
}
```
